### PR TITLE
Prevent, handle missing trips

### DIFF
--- a/src/js/models/Stop.js
+++ b/src/js/models/Stop.js
@@ -20,10 +20,14 @@ function Stop(data) {
     this.lon = ko.observable(data.stop_lon);
     this.timezone = ko.observable(data.stop_timezone);
     this.url = ko.observable(data.url);
-    this.errorMsg = ko.observable();
 
     this.stopDetails = new StopDetails(this.routeID(), this.directionID(), this.stopID());
     this.trips = ko.observableArray();
+
+    this._errorMsg = ko.observable();
+    this.errorMsg = ko.computed(function() {
+        return this.stopDetails.errorMsg() || this._errorMsg();
+    }, this);
 
     this.cssId = ko.observable('stop-' + data.stop_id);
 
@@ -69,18 +73,20 @@ Stop.prototype = {
 
         this.stopDetails.fetch()
             .progress(function(msg) {
-                this.errorMsg(msg);
+                this._errorMsg(msg);
             }.bind(this))
             .then(function() {
-                this.trips(this.stopDetails.tripCollection.trips());
+                if (this.stopDetails.tripCollection) {
+                    this.trips(this.stopDetails.tripCollection.trips());
+                }
                 this.loadedTrips(true);
                 this.loading(false);
-                this.errorMsg(null);
+                this._errorMsg(null);
             }.bind(this))
             .catch(function(e) {
                 this.loadedTrips(false);
                 this.loading(false);
-                this.errorMsg(e.message);
+                this._errorMsg(e.message);
             }.bind(this));
     },
     setupMarker: function() {

--- a/src/js/models/StopDetails.js
+++ b/src/js/models/StopDetails.js
@@ -35,7 +35,12 @@ StopDetails.prototype.fetch = function() {
         requests.get(yqlURL, params)
             .then(this.parseResponse.bind(this))
             .tap(function(Runs) {
-                this.tripCollection = new TripCollection(this.stopID(), this.routeID(), Runs);
+                if (Runs.length > 0) {
+                    this.tripCollection = new TripCollection(this.stopID(), this.routeID(), Runs);
+                }
+                else {
+                    this.errorMsg("No trips available at this time.");
+                }
                 deferred.resolve();
             }.bind(this))
             .catch(CapMetroAPIError, function(err) {
@@ -91,8 +96,7 @@ StopDetails.prototype.parseResponse = function(res) {
         var runDirection = utils.formatDirection(Run.Route, Run.Direction);
 
         var routeMatches = Run.Route == this.routeID() && stopDirection == runDirection;
-        var validRealtime = Run.Realtime.Valid == "Y";
-        return routeMatches && validRealtime;
+        return routeMatches;
     }.bind(this));
 
     return Runs;


### PR DESCRIPTION
* Realtime trips are marked invalid (`Realtime.Valid` is `N`) when a route is not in service, so there are no valid trips once the vehicles stop running. 
    * [Response when not in service](https://gist.github.com/scascketta/2e01cb376a0baeb3cd44).

* Check if there are valid trips, and display message if otherwise.